### PR TITLE
[BREAKING] Submodule reversal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "pages"]
-	path = pages
-	url = https://github.com/StrataSource/Wiki
-	branch = system-migration

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Hi! This is our wiki software. It uses Markdown files in order to compile static HTML files which can be deployed to the web.
 
+> ⚠️ **This is a submodule!** Please put it in a folder called `generator`. Put the `pages` folder next to it with the pages structure inside. For a working setup, please check [the current wiki repo](https://github.com/StrataSource/Wiki/tree/system-migration)
+
 ## Installation
 
 To install the wiki, clone it and simply run `npm i`.
@@ -10,7 +12,7 @@ To install the wiki, clone it and simply run `npm i`.
 
 In order to run the development server, run `npm run dev`. Wrangler has to be installed for this to work.
 
-⚠ The dev server doesn't update in realtime anymore for the sake of performance. Please recompile if you changed something.
+> ⚠️ The dev server doesn't update in realtime anymore for the sake of performance. Please recompile if you changed something.
 
 ## Building
 

--- a/src/common/slug.ts
+++ b/src/common/slug.ts
@@ -49,9 +49,9 @@ export class Slug {
 
         let found = false;
         for (const path of possiblePaths) {
-            console.log('Checking file path', 'pages/' + path);
-            if (fs.existsSync('pages/' + path)) {
-                this.path = 'pages/' + path;
+            console.log('Checking file path', '../pages/' + path);
+            if (fs.existsSync('../pages/' + path)) {
+                this.path = '../pages/' + path;
                 console.log('Found file at path', path);
                 found = true;
                 break;

--- a/src/exporter/pages.ts
+++ b/src/exporter/pages.ts
@@ -15,10 +15,10 @@ export class PageHandler {
         this.exporter = exporter;
 
         this.games = fs
-            .readdirSync('pages')
-            .filter((game) => fs.existsSync(`pages/${game}/meta.json`))
+            .readdirSync('../pages')
+            .filter((game) => fs.existsSync(`../pages/${game}/meta.json`))
             .map((game) => ({
-                ...fs.readJSONSync(`pages/${game}/meta.json`),
+                ...fs.readJSONSync(`../pages/${game}/meta.json`),
                 id: game
             }));
     }

--- a/static/assets/js/navigation.js
+++ b/static/assets/js/navigation.js
@@ -126,7 +126,7 @@ async function navigate(slug, replace = false, loadData = true) {
 
     if (loadData || data.file) {
         document.querySelector('.edit a').href = `https://github.com/StrataSource/Wiki/edit/system-migration/${
-            data.file ? data.file.slice(6) : '404.md'
+            data.file ? data.file.slice(3) : '404.md'
         }`;
     }
 


### PR DESCRIPTION
This reverses the submodule order to have this repo submoduled inside the other repo. Due to this change, the CloudFlare configuration must be updated.
Please create a pages instance that uses `StrataSource/Wiki` on the `system-migration` branch, has the build command `npm run cf-build` and the output directory of `generator/public`.
Please also update your personal setups accordingly.