### PR TITLE
Show all games for the shared game

### DIFF
--- a/src/exporter/pages.ts
+++ b/src/exporter/pages.ts
@@ -14,6 +14,7 @@ export class PageHandler {
     constructor(exporter) {
         this.exporter = exporter;
 
+        // Read the pages folder, anything with a meta.json is a "game"
         this.games = fs
             .readdirSync('../pages')
             .filter((game) => fs.existsSync(`../pages/${game}/meta.json`))
@@ -27,6 +28,7 @@ export class PageHandler {
         const index = {};
         const menu = {};
 
+        // For each game, for each category, for each topic, render all articles
         for (const game of this.games) {
             index[game.id] = {
                 id: game.id,
@@ -37,6 +39,7 @@ export class PageHandler {
             menu[game.id] = {};
 
             for (const category of game.categories) {
+                // If this category is just a redirect,
                 if (category.redirect) {
                     index[game.id].categories[category.id] = {
                         id: category.id,
@@ -84,10 +87,12 @@ export class PageHandler {
                     for (let articleString of articles) {
                         articleString = articleString.replace('.md', '');
 
+                        // Render out the markdown
                         const result = this.exporter.renderer.renderPage(
                             new Slug(`${game.id}/${category.id}/${topic.id}/${articleString}`)
                         );
 
+                        // Make sure the current game's feature set allows this article
                         const meta = result.meta;
                         if (
                             Array.isArray(meta.features) &&

--- a/src/exporter/render.ts
+++ b/src/exporter/render.ts
@@ -30,6 +30,7 @@ export class Renderer {
             }
         }).use(markdownItFrontMatter, (frontMatter) => (this.tempMetaValue = yaml.parse(frontMatter)));
 
+        // For each game, register up a handler for its game exclusive block
         for (const game of this.exporter.pageHandler.games) {
             console.log('Registered game', game.id);
 

--- a/src/exporter/render.ts
+++ b/src/exporter/render.ts
@@ -39,7 +39,7 @@ export class Renderer {
                 render: (tokens, idx) =>
                     tokens[idx].nesting === 1
                         ? // opening tag
-                          `<div class='${game.id}-only exclusive'><div class="exclusive-header">${
+                          `<div class='theme-${game.id} exclusive'><div class="exclusive-header">${
                               game.nameShort || game.name || game.id
                           } only!</div>\n`
                         : // closing tag

--- a/static/assets/css/global.css
+++ b/static/assets/css/global.css
@@ -377,6 +377,9 @@ dialog .close {
     border-radius: 0.5rem;
     width: fit-content;
     max-width: 100%;
+
+    /* These are hidden by default and will by enabled by the page */
+    display: none;
 }
 
 .content h1,

--- a/static/assets/js/navigation.js
+++ b/static/assets/js/navigation.js
@@ -90,20 +90,33 @@ async function navigate(slug, replace = false, loadData = true) {
 
     clearNotices();
 
-    const exclusives = document.querySelectorAll('.exclusive');
-    let showExclusiveNotice = false;
 
-    for (const exclusive of exclusives) {
-        if (!exclusive.className.includes(info.game)) {
-            exclusive.remove();
-            showExclusiveNotice = true;
+    // Grab all of the exclusive blocks and filter 'em
+    const exclusives = document.querySelectorAll('.exclusive');
+
+    if ( info.game === "shared" ) {
+        // If this is the "shared" game, we want to always display all exclusive blocks
+        for (const exclusive of exclusives) {
+            exclusive.style.display = "block";
         }
-    }
-    if (showExclusiveNotice) {
-        notify(
-            `This page contains sections that are irrelevant to your selected game. If you're missing a section, consider <a href="javascript:showGameSelector()">changing your game</a>.`,
-            'eye-off'
-        );
+    } else {
+        // Hide any exclusive blocks that aren't related to the current game
+        let showExclusiveNotice = false;
+
+        for (const exclusive of exclusives) {
+            if (exclusive.className.includes(info.game)) {
+                exclusive.style.display = "block";
+            } else {
+                showExclusiveNotice = true;
+            }
+        }
+        
+        if (showExclusiveNotice) {
+            notify(
+                `This page contains sections that are irrelevant to your selected game. If you're missing a section, consider <a href="javascript:showGameSelector()">changing your game</a>.`,
+                'eye-off'
+            );
+        }
     }
 
     if (data.meta.example) {


### PR DESCRIPTION
This makes it so that from the shared game, you can see all exclusive blocks at once. Makes it much more convenient and makes the game selector act more like a filter.

This depends on this other PR
https://github.com/StrataSource/Wiki/pull/31

