### PR TITLE
Fixed naming convention in vscript parser

### DIFF
--- a/src/lib/parsers/vscript.server.ts
+++ b/src/lib/parsers/vscript.server.ts
@@ -100,7 +100,7 @@ export function getVscriptTopic(p: string) {
             meta: {
                 title: c,
                 weight: c == "Globals" ? 0 : undefined,
-                features: ["VSCRIPT"],
+                features: ["USE_VSCRIPT"],
             },
         });
     }
@@ -113,6 +113,6 @@ export function getVscriptPageMeta(p: string, name: string): ArticleMeta {
         id: name,
         title: name,
         disablePageActions: true,
-        features: ["VSCRIPT"],
+        features: ["USE_VSCRIPT"],
     };
 }


### PR DESCRIPTION
Renamed it from `VSCRIPT` to `USE_VSCRIPT` to have it follow convention