### PR TITLE
DRAFT AngelScript: Adding support for displaying Hammer objects in the reference API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Strata Wiki
+# Strata Source Wiki Software
 
 [![Strata Source](https://branding.stratasource.org/i/strata/logo/ondark/color.svg)](https://stratasource.org)
 
-Welcome to the Strata Wiki!
+Welcome to the Strata Source Wiki Software repository!
 
-This is the custom wiki software that powers the Wiki for most of our games. If you're looking to edit the contents of the Wiki or to build and run local instances of the Wiki, check out [the documentation Wiki repository](https://github.com/StrataSource/wiki/).
+This is the custom software that powers the Wiki for most of our games. If you're looking to edit the contents of the Wiki or to build and run local instances of the Wiki, check out [the documentation Wiki repository](https://github.com/StrataSource/wiki/).

--- a/src/lib/parsers/angelscript.server.ts
+++ b/src/lib/parsers/angelscript.server.ts
@@ -4,9 +4,10 @@ import { parseMarkdown } from "./markdown.server";
 import { reportLint } from "$lib/linter.server";
 import { urlifyString } from "$lib/util";
 
-type ASScope = 
+type ASScope =
     | "server"
-    | "client";
+    | "client"
+    | "hammer";
 
 interface ASNamed {
     namespace: string|undefined;
@@ -79,8 +80,18 @@ function getASArticleScope(o: {scope?: ASScope[];}): ArticleScope|undefined
 
     const server = o.scope.includes("server");
     const client = o.scope.includes("client");
-    
-    return server && client ? "shared" : ( server ? "server" : (client ? "client" : undefined))
+    const hammer = o.scope.includes("hammer");
+
+    if (server && client)
+        return "shared";
+    else if (server)
+        return "server";
+    else if (client)
+        return "client";
+    else if (hammer)
+        return "hammer";
+
+    return undefined;
 }
 
 function compareScope(a: {scope?: ASScope[];}, b: {scope?: ASScope[];})
@@ -89,7 +100,7 @@ function compareScope(a: {scope?: ASScope[];}, b: {scope?: ASScope[];})
     return getASArticleScope(a) === getASArticleScope(b);
 }
 
-let angelscriptDump: ASDump = { namespace: [], enum: [], property: [], function: [], type: [] };
+const angelscriptDump: ASDump = { namespace: [], enum: [], property: [], function: [], type: [] };
 
 function isValidTypeName(type: string) {
     if(baseTypeNames.includes(type)) {
@@ -176,7 +187,7 @@ function mergeDump(scope: ASScope, dump: ASDump)
         } else {
             ft.scope?.push(scope);
         }
-        
+
         // TODO: Combine mismatches!
         if((ot.base_type ? getASName(ot.base_type) : undefined) != (ft.base_type ? getASName(ft.base_type) : undefined) || ot.template_parameter?.length != ft.template_parameter?.length) {
             console.log(ot);
@@ -213,15 +224,19 @@ function compareNamed(a: ASNamed, b: ASNamed): number {
 }
 
 function parseJSON() {
-    let server: ASDump = JSON.parse(
+    const server: ASDump = JSON.parse(
         fs.readFileSync(`../dumps/angelscript_server_p2ce.json`, "utf-8")
     );
-    let client: ASDump = JSON.parse(
+    const client: ASDump = JSON.parse(
         fs.readFileSync(`../dumps/angelscript_client_p2ce.json`, "utf-8")
     );
-    
+    const hammer: ASDump = JSON.parse(
+        fs.readFileSync(`../dumps/anglescript_hammer_p2ce.json`, "utf-8")
+    );
+
     mergeDump("server", server);
     mergeDump("client", client);
+    mergeDump("hammer", hammer);
 
     // Sort everything
     angelscriptDump.enum.sort((a, b) => compareNamed(a, b));
@@ -237,10 +252,12 @@ function getScopeString(o: ASNamed): string {
 
     if(scope === "shared") {
         return "Server & Client";
-    } else if(scope === "server") {
+    } else if (scope === "server") {
         return "Server Only";
-    } else if(scope === "client") {
+    } else if (scope === "client") {
         return "Client Only";
+    } else if (scope === "hammer") {
+        return "Hammer";
     }
 
     return "Unknown";
@@ -291,7 +308,7 @@ function renderFunctionPages(name: string, p: string, functions: ASFunction[]): 
     for( const asFunc of asFuncs )
     {
         out.push(getScopeString(asFunc));
-        
+
         if (asFunc.documentation) {
             out.push(asFunc.documentation);
         }
@@ -332,17 +349,22 @@ function renderPropertyPage(p: string, properties: ASProperty[], subtext?: boole
     const server: ASProperty[] = properties.filter(o => getASArticleScope(o) === "server");
     const client: ASProperty[] = properties.filter(o => getASArticleScope(o) === "client");
     const shared: ASProperty[] = properties.filter(o => getASArticleScope(o) === "shared");
+    const hammer: ASProperty[] = properties.filter(o => getASArticleScope(o) === "hammer");
 
-    if(shared.length > 0) {
+    if (shared.length > 0) {
         out.push(...renderPropertyPageInternal(p, shared, header + " - Shared"));
     }
 
-    if(server.length > 0) {
+    if (server.length > 0) {
         out.push(...renderPropertyPageInternal(p, server, header + " - Server"));
     }
 
-    if(client.length > 0) {
+    if (client.length > 0) {
         out.push(...renderPropertyPageInternal(p, client, header + " - Client"));
+    }
+
+    if (hammer.length > 0) {
+        out.push(...renderPropertyPageInternal(p, hammer, header + " - Hammer"));
     }
 
     return out;
@@ -354,9 +376,9 @@ function renderMethods(parent: ASNamed, methods: ASFunction[])
     for(const asMethod of methods) {
 
         const scopeSuffix = compareScope(parent, asMethod) ? "" : ` (${getScopeString(asMethod)})`;
-    
+
         out.push(`### ${asMethod.name}${scopeSuffix}`);
-        
+
         if (asMethod.documentation) {
             out.push(asMethod.documentation);
         }
@@ -449,7 +471,7 @@ function renderTypePages(name: string, p: string): string[] {
             out.push(`### Inherited From ${name}`);
             out.push(...renderMethods(asBaseType, asBaseType.method));
         }
-        
+
         base = asBaseType.base_type;
     }
 
@@ -508,7 +530,7 @@ function getAngelScriptIndex(p: string): PageGeneratorIndex {
         });
     }
     index.topics.push(enumTopic);
-    
+
     const funcTopic: MenuTopic = {
         type: "angelscript",
         id: `${p}/function`,
@@ -518,7 +540,7 @@ function getAngelScriptIndex(p: string): PageGeneratorIndex {
         subtopics: [],
     };
     for (const o of angelscriptDump.function) {
-        
+
         // Gross... Need to not emit overloads
         const f = funcTopic.articles.find((a) => a.id === urlifyString(getASName(o)));
         if (f) {

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -29,10 +29,11 @@ interface BasePageMeta {
     weight?: number;
 }
 
-type ArticleScope = 
+type ArticleScope =
     | "server"
     | "client"
-    | "shared";
+    | "shared"
+    | "hammer";
 
 // Articles are the pages you read
 interface ArticleMeta extends BasePageMeta {

--- a/src/routes/SidebarTopic.svelte
+++ b/src/routes/SidebarTopic.svelte
@@ -14,6 +14,7 @@
         mdiBlockHelper,
         mdiCircle,
         mdiCircleHalfFull,
+        mdiHammer,
         mdiDelete,
         mdiFlaskEmpty,
         mdiSelectionEllipse,
@@ -57,7 +58,6 @@
                 {/if}
 
                 {#each filterArticles(topic.articles) as article, i}
-
                     {#if i < 100 || loaded}
                         <a
                             class="item"
@@ -111,6 +111,10 @@
                                     {:else if article.meta.scope == "client"}
                                         <span title="Client">
                                             <Icon d={mdiCircleHalfFull} mirror inline></Icon>
+                                        </span>
+                                    {:else if article.meta.scope == "hammer"}
+                                        <span title="Hammer">
+                                            <Icon d={mdiHammer} mirror inline></Icon>
                                         </span>
                                     {/if}
                                 {/if}


### PR DESCRIPTION
The current implementation of the AngelScript (AS) wiki dump parser parses the server and client dump files. However, since there is currently no real difference between the two, all functions, enums, and types are marked as "Server & Client". The only AS implementation difference in Strata Source is with Hammer, which includes various class types and enums that are NOT in the game. Ex. `BoundBox`, `RenderMode`

Right now, as of 1/4/26, the parser has an issue if a type or enum exists in BOTH the game and Hammer. An example is `Material`, where `Material` exists to a far greater extent than Hammer, with several functions in the class definition. However, for Hammer, it's an empty shell. The "mergeDump" function currently doesn't handle a type already being defined and instead overwrites what's already there with the next dump to be merged. It wasn't an issue with the client & server ones since they were currently the same, but not the Hammer one.

The goal of this PR is to rewrite/update the AS wiki parser to support the Hammer dump file. This PR might evolve into rewriting the entire dump parsing scene, so that all scripting languages can be parsed from one file and formatted into the same format in the wiki itself.