### PR TITLE
AngelScript: Adding support for displaying Hammer objects in the reference API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Strata Wiki
+# Strata Source Wiki Software
 
 [![Strata Source](https://branding.stratasource.org/i/strata/logo/ondark/color.svg)](https://stratasource.org)
 
-Welcome to the Strata Wiki!
+Welcome to the Strata Source Wiki Software repository!
 
-This is the custom wiki software that powers the Wiki for most of our games. If you're looking to edit the contents of the Wiki or to build and run local instances of the Wiki, check out [the documentation Wiki repository](https://github.com/StrataSource/wiki/).
+This is the custom software that powers the Wiki for most of our games. If you're looking to edit the contents of the Wiki or to build and run local instances of the Wiki, check out [the documentation Wiki repository](https://github.com/StrataSource/wiki/).

--- a/src/lib/parsers/angelscript.server.ts
+++ b/src/lib/parsers/angelscript.server.ts
@@ -231,7 +231,7 @@ function parseJSON() {
         fs.readFileSync(`../dumps/angelscript_client_p2ce.json`, "utf-8")
     );
     const hammer: ASDump = JSON.parse(
-        fs.readFileSync(`../dumps/anglescript_hammer_p2ce.json`, "utf-8")
+        fs.readFileSync(`../dumps/angelscript_hammer_p2ce.json`, "utf-8")
     );
 
     mergeDump("server", server);

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -29,10 +29,11 @@ interface BasePageMeta {
     weight?: number;
 }
 
-type ArticleScope = 
+type ArticleScope =
     | "server"
     | "client"
-    | "shared";
+    | "shared"
+    | "hammer";
 
 // Articles are the pages you read
 interface ArticleMeta extends BasePageMeta {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
     import Card from "$lib/components/Card.svelte";
 
     import heroHeader from "$lib/assets/heroHeader.svg";
-    import {
+    import { // List of material icons that will be used on the Home page.
         mdiAccountGroup,
         mdiAlphaVBox,
         mdiConsoleLine,
@@ -22,153 +22,154 @@
     import Metadata from "$lib/components/Metadata.svelte";
     import { dev } from "$app/environment";
 
+    // The list of categories that are featured on the Wiki home page.
     const categories: (
         | {
-              id: string;
-              title: string;
-              description: string;
-              icon: string;
-              seperation: false;
+              id: string; // The article (without the ".md") that should be entered into by default when the category is selected.
+              title: string; // Title displayed for the category.
+              description: string; // Description of the category.
+              icon: string; // Icon to use for the category displayed before the "title". Recommended to use a icon imported from the material icons package.
+              separation: false; // This should be left false for category entrees.
           }
-        | { title: string; seperation: true }
+        | { title: string; separation: true; } // Alternate structure for headers separators.
     )[] = [
-        /* { seperation: true, title: "Getting started" },
+        /* { separation: true, title: "Getting sSarted" },
         {
             id: "todo",
             title: "Mapping",
             description: "Creating content in Strata Source",
             icon: mdiGridLarge,
-            seperation: false,
+            separation: false,
         }, */
-        { seperation: true, title: "Reference" },
+        { separation: true, title: "Reference" },
         /* {
             id: "todo",
             title: "Sound Operators",
             description: "List of sound operators",
             icon: mdiVolumeHigh,
-            seperation: false,
+            separation: false,
         }, */
         {
             id: "modding/overview",
             title: "Modding",
-            description: "Modding Strata Source games",
+            description: "Modding Strata Source Games",
             icon: mdiLayers,
-            seperation: false,
+            separation: false,
         },
         {
             id: "entities/reference",
             title: "Entities",
             description: "Engine Entity Reference",
             icon: mdiSphere,
-            seperation: false,
+            separation: false,
         },
         {
             id: "material/reference",
             title: "Materials",
             description: "Material Reference",
             icon: mdiCubeOutline,
-            seperation: false,
+            separation: false,
         },
         {
             id: "lighting/clustered",
             title: "Lighting",
-            description: "Lighting reference",
+            description: "Lighting Reference",
             icon: mdiLightbulb,
-            seperation: false,
+            separation: false,
         },
         {
             id: "audio/overview/overview",
             title: "Audio",
             description: "Audio Reference",
             icon: mdiSpeaker,
-            seperation: false,
+            separation: false,
         },
         {
             id: "console/command",
             title: "Console",
-            description: "ConCommands and ConVars Reference",
+            description: "ConCommands & ConVars Reference",
             icon: mdiConsoleLine,
-            seperation: false,
+            separation: false,
         },
         {
             id: "misc",
             title: "Misc",
             description: "Miscellaneous Pages",
             icon: mdiDiceMultiple,
-            seperation: false,
+            separation: false,
         },
         {
             id: "community",
             title: "Community",
             description: "Community Tools & Resources",
             icon: mdiWrench,
-            seperation: false,
+            separation: false,
         },
-        { seperation: true, title: "Scripting" },
+        { separation: true, title: "Scripting" },
         {
-            id: "angelscript/game",
-            title: "Angelscript",
-            description: "Reference for Angelscript language",
+            id: "angelscript/index",
+            title: "AngelScript",
+            description: "Reference for The AngelScript Scripting System",
             icon: mdiScript,
-            seperation: false,
+            separation: false,
         },
         {
             id: "vscript/reference/Globals",
             title: "VScript",
-            description: "Reference for VScript language",
+            description: "Reference for the VScript Scripting System",
             icon: mdiAlphaVBox,
-            seperation: false,
+            separation: false,
         },
         {
             id: "panorama/overview/getting-started",
             title: "Panorama",
             description: "In-Game UI Framework",
             icon: mdiViewDashboard,
-            seperation: false,
-        } /* 
+            separation: false,
+        } /*
         {
             id: "todo",
             title: "Game Events",
             description: "Documentation for every game event",
             icon: mdiNetwork,
-            seperation: false,
+            separation: false,
         },
-        { seperation: true, title: "Assets" },
+        { separation: true, title: "Assets" },
         {
             id: "todo",
             title: "Material Proxies",
             description: "Material Proxy Reference",
             icon: mdiCubeScan,
-            seperation: false,
+            separation: false,
         },
         {
             id: "todo",
             title: "Animation",
             description: "Maybe?",
             icon: mdiAnimation,
-            seperation: false,
+            separation: false,
         },
         {
             id: "todo",
             title: "Model Compilation",
             description: "Compiling and QC files",
             icon: mdiFileDocument,
-            seperation: false,
+            separation: false,
         }, */,
-        { seperation: true, title: "Contributing" },
+        { separation: true, title: "Contributing" },
         {
             id: "contribute/basics/getting-started",
-            title: "Contribute to the wiki",
-            description: "How to write content for the wiki",
+            title: "Contribute to The Wiki",
+            description: "How to contribute to the Strata Source Wiki.",
             icon: mdiAccountGroup,
-            seperation: false,
+            separation: false,
         },
         {
-            id: dev ? "test" : "",
-            title: "Test suite",
-            description: "(Dev only) Suite for testing the Wiki",
+            id: dev ? "test" : "", // The Test Suite should only appear in local non-production builds of the Wiki.
+            title: "Test Suite",
+            description: "(Dev Only) Suite for testing the Wiki elements and features.",
             icon: mdiTestTube,
-            seperation: false,
+            separation: false,
         },
     ];
 </script>
@@ -178,7 +179,7 @@
 <div class="hero" style:--i="url({heroHeader})">
     <Container>
         <div>
-            <h1>Welcome to the Strata Wiki</h1>
+            <h1>Welcome to the Strata Source Wiki</h1>
         </div>
     </Container>
 </div>
@@ -186,7 +187,7 @@
 <Container>
     <div class="grid">
         {#each categories as category}
-            {#if category.seperation}
+            {#if category.separation}
                 <div class="section">
                     <h2>{category.title}</h2>
                 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,7 +33,7 @@
           }
         | { title: string; separation: true; } // Alternate structure for headers separators.
     )[] = [
-        /* { separation: true, title: "Getting sSarted" },
+        /* { separation: true, title: "Getting Started" },
         {
             id: "todo",
             title: "Mapping",

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -10,7 +10,7 @@
         "Portal 2: Wiki Edition",
         "Sixteen Times The Pages",
         "Not to be confused with the Strata Layer",
-        "To be confused with the Strata Wiki",
+        "To be confused with the Strata Source Wiki",
         "Making Source 20% cooler",
         "Works on my machine™",
         "Beware: ambient_generic on premises",

--- a/src/routes/SidebarTopic.svelte
+++ b/src/routes/SidebarTopic.svelte
@@ -14,6 +14,7 @@
         mdiBlockHelper,
         mdiCircle,
         mdiCircleHalfFull,
+        mdiHammer,
         mdiDelete,
         mdiFlaskEmpty,
         mdiSelectionEllipse,
@@ -57,7 +58,6 @@
                 {/if}
 
                 {#each filterArticles(topic.articles) as article, i}
-
                     {#if i < 100 || loaded}
                         <a
                             class="item"
@@ -85,8 +85,7 @@
                                 {#if (article.meta?.features?.length || 0) > 0 && !getGamesWithSupport(article.meta.features || []).all}
                                     {#if $currentGame == ""}
                                         <span title="Limited support">
-                                            <Icon d={mdiSelectionEllipse} inline
-                                            ></Icon>
+                                            <Icon d={mdiSelectionEllipse} inline></Icon>
                                         </span>
                                     {:else if !getGamesWithSupport(article.meta.features || []).games.includes($currentGame)}
                                         <span
@@ -111,6 +110,10 @@
                                     {:else if article.meta.scope == "client"}
                                         <span title="Client">
                                             <Icon d={mdiCircleHalfFull} mirror inline></Icon>
+                                        </span>
+                                    {:else if article.meta.scope == "hammer"}
+                                        <span title="Hammer">
+                                            <Icon d={mdiHammer} inline></Icon>
                                         </span>
                                     {/if}
                                 {/if}


### PR DESCRIPTION
The current implementation of the AngelScript (AS) wiki dump parser parses the server and client dump files. However, since there is currently no real difference between the two, all functions, enums, and types are marked as "Server & Client". The only AS implementation difference in Strata Source is with Hammer, which includes various class types and enums that are NOT in the game. Ex. `BoundBox`, `RenderMode`

Right now, as of 1/4/26, the parser has an issue if a type or enum exists in BOTH the game and Hammer. An example is `Material`, where `Material` exists to a far greater extent than Hammer, with several functions in the class definition. However, for Hammer, it's an empty shell. The "mergeDump" function currently doesn't handle a type already being defined and instead overwrites what's already there with the next dump to be merged. It wasn't an issue with the client & server ones since they were currently the same, but not the Hammer one.

The goal of this PR is to rewrite/update the AS wiki parser to support the Hammer dump file. This PR might evolve into rewriting the entire dump parsing scene, so that all scripting languages can be parsed from using one parsing file and formatted into the same format for wiki-wide consistency.

TODO:
- [ ] Get a nicer icon for Hammer-specific types. This should be able to help make some custom icons: https://github.com/Templarian/MaterialDesign-Font-Build
- [ ] Rewrite/Update the current AngelScript parser to support both the game and Hammer dumps correctly.
- [ ] Add a new page type, a folder that also acts as a article.