### PR TITLE
Feat: Front Menu Cleanup, Menu Code Comments, Additional Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Strata Wiki
+# Strata Source Wiki Software
 
 [![Strata Source](https://branding.stratasource.org/i/strata/logo/ondark/color.svg)](https://stratasource.org)
 
-Welcome to the Strata Wiki!
+Welcome to the Strata Source Wiki Software repository!
 
-This is the custom wiki software that powers the Wiki for most of our games. If you're looking to edit the contents of the Wiki or to build and run local instances of the Wiki, check out [the documentation Wiki repository](https://github.com/StrataSource/wiki/).
+This is the custom software that powers the Wiki for most of our games. If you're looking to edit the contents of the Wiki or to build and run local instances of the Wiki, check out [the documentation Wiki repository](https://github.com/StrataSource/wiki/).

--- a/src/lib/components/GameSelector.svelte
+++ b/src/lib/components/GameSelector.svelte
@@ -10,7 +10,7 @@
             Disable support info
         {/if}
     </option>
-    {#each Object.entries($gameMeta) as [id, game]}
+    {#each Object.entries($gameMeta) as [id, game] (game.name)}
         <option value={id}>{game.name}</option>
     {/each}
 </select>

--- a/src/lib/components/renderers/ListRenderer.svelte
+++ b/src/lib/components/renderers/ListRenderer.svelte
@@ -11,9 +11,9 @@
 </script>
 
 <svelte:element this={dat.ordered ? "ol" : "ul"}>
-    {#each dat.children as child}
+    {#each dat.children as child (child.position)}
         <li>
-            {#each child.children as c}
+            {#each child.children as c (c.position)}
                 <RootRenderer dat={c}></RootRenderer>
             {/each}
         </li>

--- a/src/lib/components/renderers/NoticeRenderer.svelte
+++ b/src/lib/components/renderers/NoticeRenderer.svelte
@@ -68,7 +68,7 @@
 </script>
 
 <Notice {type} {game}>
-    {#each d.children as child, i}
+    {#each d.children as child, i (i)}
         <RootRenderer dat={child} {i}></RootRenderer>
     {/each}
 </Notice>

--- a/src/lib/components/renderers/StringRenderer.svelte
+++ b/src/lib/components/renderers/StringRenderer.svelte
@@ -21,7 +21,7 @@
     };
 </script>
 
-{#each dat as e}
+{#each dat as e (e.position)}
     {#if e.type == "text" || e.type == "html"}
         {e.value}
     {:else if e.type == "break"}

--- a/src/lib/components/renderers/TableRenderer.svelte
+++ b/src/lib/components/renderers/TableRenderer.svelte
@@ -13,9 +13,9 @@
 <div class="wrapper">
     <table>
         <tbody>
-            {#each dat.children as row}
+            {#each dat.children as row (row.position)}
                 <tr>
-                    {#each row.children as cell, i}
+                    {#each row.children as cell, i (i)}
                         <td
                             style:text-align={dat.align
                                 ? dat.align[i]
@@ -44,7 +44,7 @@
         border: none;
         text-wrap: nowrap;
     }
-    
+
     tr {
         border-bottom: solid 0.1rem #8882;
     }

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -29,7 +29,7 @@ interface BasePageMeta {
     weight?: number;
 }
 
-type ArticleScope = 
+type ArticleScope =
     | "server"
     | "client"
     | "shared";
@@ -85,6 +85,6 @@ interface PageGeneratorIndex {
 
 interface PageGenerator {
     init: () => void;
-    getPageContent: (path: string, article: string) => any;
+    getPageContent: (path: string, article: string) => void;
     getIndex: (path: string) => PageGeneratorIndex;
 }

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -85,6 +85,6 @@ interface PageGeneratorIndex {
 
 interface PageGenerator {
     init: () => void;
-    getPageContent: (path: string, article: string) => void;
+    getPageContent: (path: string, article: string) => any;
     getIndex: (path: string) => PageGeneratorIndex;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,147 +28,148 @@
               title: string;
               description: string;
               icon: string;
-              seperation: false;
+              separation: false;
           }
-        | { title: string; seperation: true }
+        | { title: string; separation: true }
     )[] = [
-        /* { seperation: true, title: "Getting started" },
+        /* { separation: true, title: "Getting started" },
         {
             id: "todo",
             title: "Mapping",
             description: "Creating content in Strata Source",
             icon: mdiGridLarge,
-            seperation: false,
+            separation: false,
         }, */
-        { seperation: true, title: "Reference" },
+        { separation: true, title: "Reference" },
         /* {
             id: "todo",
             title: "Sound Operators",
             description: "List of sound operators",
             icon: mdiVolumeHigh,
-            seperation: false,
+            separation: false,
         }, */
         {
             id: "modding/overview",
             title: "Modding",
             description: "Modding Strata Source games",
             icon: mdiLayers,
-            seperation: false,
+            separation: false,
         },
         {
             id: "entities/reference",
             title: "Entities",
             description: "Engine Entity Reference",
             icon: mdiSphere,
-            seperation: false,
+            separation: false,
         },
         {
             id: "material/reference",
             title: "Materials",
             description: "Material Reference",
             icon: mdiCubeOutline,
-            seperation: false,
+            separation: false,
         },
         {
             id: "lighting/clustered",
             title: "Lighting",
             description: "Lighting reference",
             icon: mdiLightbulb,
-            seperation: false,
+            separation: false,
         },
         {
             id: "audio/overview/overview",
             title: "Audio",
             description: "Audio Reference",
             icon: mdiSpeaker,
-            seperation: false,
+            separation: false,
         },
         {
             id: "console/command",
             title: "Console",
             description: "ConCommands and ConVars Reference",
             icon: mdiConsoleLine,
-            seperation: false,
+            separation: false,
         },
         {
             id: "misc",
             title: "Misc",
             description: "Miscellaneous Pages",
             icon: mdiDiceMultiple,
-            seperation: false,
+            separation: false,
         },
         {
             id: "community",
             title: "Community",
             description: "Community Tools & Resources",
             icon: mdiWrench,
-            seperation: false,
+            separation: false,
         },
-        { seperation: true, title: "Scripting" },
+        { separation: true, title: "Scripting" },
         {
             id: "angelscript/game",
             title: "Angelscript",
             description: "Reference for Angelscript language",
             icon: mdiScript,
-            seperation: false,
+            separation: false,
         },
         {
             id: "vscript/reference/Globals",
             title: "VScript",
             description: "Reference for VScript language",
             icon: mdiAlphaVBox,
-            seperation: false,
+            separation: false,
         },
         {
             id: "panorama/overview/getting-started",
             title: "Panorama",
             description: "In-Game UI Framework",
             icon: mdiViewDashboard,
-            seperation: false,
-        } /* 
+            separation: false,
+        }
+        /*
         {
             id: "todo",
             title: "Game Events",
             description: "Documentation for every game event",
             icon: mdiNetwork,
-            seperation: false,
+            separation: false,
         },
-        { seperation: true, title: "Assets" },
+        { separation: true, title: "Assets" },
         {
             id: "todo",
             title: "Material Proxies",
             description: "Material Proxy Reference",
             icon: mdiCubeScan,
-            seperation: false,
+            separation: false,
         },
         {
             id: "todo",
             title: "Animation",
             description: "Maybe?",
             icon: mdiAnimation,
-            seperation: false,
+            separation: false,
         },
         {
             id: "todo",
             title: "Model Compilation",
             description: "Compiling and QC files",
             icon: mdiFileDocument,
-            seperation: false,
+            separation: false,
         }, */,
-        { seperation: true, title: "Contributing" },
+        { separation: true, title: "Contributing" },
         {
             id: "contribute/basics/getting-started",
             title: "Contribute to the wiki",
             description: "How to write content for the wiki",
             icon: mdiAccountGroup,
-            seperation: false,
+            separation: false,
         },
         {
             id: dev ? "test" : "",
             title: "Test suite",
             description: "(Dev only) Suite for testing the Wiki",
             icon: mdiTestTube,
-            seperation: false,
+            separation: false,
         },
     ];
 </script>
@@ -185,8 +186,8 @@
 
 <Container>
     <div class="grid">
-        {#each categories as category}
-            {#if category.seperation}
+        {#each categories as category (category.title)}
+            {#if category.separation}
                 <div class="section">
                     <h2>{category.title}</h2>
                 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
     import Card from "$lib/components/Card.svelte";
 
     import heroHeader from "$lib/assets/heroHeader.svg";
-    import {
+    import { // List of material icons that will be used on the Home page.
         mdiAccountGroup,
         mdiAlphaVBox,
         mdiConsoleLine,
@@ -22,17 +22,18 @@
     import Metadata from "$lib/components/Metadata.svelte";
     import { dev } from "$app/environment";
 
+    // The list of categories that are featured on the Wiki home page.
     const categories: (
         | {
-              id: string;
-              title: string;
-              description: string;
-              icon: string;
-              separation: false;
+              id: string; // The article (without the ".md") that should be entered into by default when the category is selected.
+              title: string; // Title displayed for the category.
+              description: string; // Description of the category.
+              icon: string; // Icon to use for the category displayed before the "title". Recommended to use a icon imported from the material icons package.
+              separation: false; // This should be left false for category entrees.
           }
-        | { title: string; separation: true }
+        | { title: string; separation: true; } // Alternate structure for headers separators.
     )[] = [
-        /* { separation: true, title: "Getting started" },
+        /* { separation: true, title: "Getting Started" },
         {
             id: "todo",
             title: "Mapping",
@@ -51,7 +52,7 @@
         {
             id: "modding/overview",
             title: "Modding",
-            description: "Modding Strata Source games",
+            description: "Modding Strata Source Games",
             icon: mdiLayers,
             separation: false,
         },
@@ -72,7 +73,7 @@
         {
             id: "lighting/clustered",
             title: "Lighting",
-            description: "Lighting reference",
+            description: "Lighting Reference",
             icon: mdiLightbulb,
             separation: false,
         },
@@ -86,7 +87,7 @@
         {
             id: "console/command",
             title: "Console",
-            description: "ConCommands and ConVars Reference",
+            description: "ConCommands & ConVars Reference",
             icon: mdiConsoleLine,
             separation: false,
         },
@@ -106,16 +107,16 @@
         },
         { separation: true, title: "Scripting" },
         {
-            id: "angelscript/game",
-            title: "Angelscript",
-            description: "Reference for Angelscript language",
+            id: "angelscript/index",
+            title: "AngelScript",
+            description: "Reference for The AngelScript Scripting System",
             icon: mdiScript,
             separation: false,
         },
         {
             id: "vscript/reference/Globals",
             title: "VScript",
-            description: "Reference for VScript language",
+            description: "Reference for the VScript Scripting System",
             icon: mdiAlphaVBox,
             separation: false,
         },
@@ -159,15 +160,15 @@
         { separation: true, title: "Contributing" },
         {
             id: "contribute/basics/getting-started",
-            title: "Contribute to the wiki",
-            description: "How to write content for the wiki",
+            title: "Contribute to The Wiki",
+            description: "How to contribute to the Strata Source Wiki.",
             icon: mdiAccountGroup,
             separation: false,
         },
         {
-            id: dev ? "test" : "",
-            title: "Test suite",
-            description: "(Dev only) Suite for testing the Wiki",
+            id: dev ? "test" : "", // The Test Suite should only appear in local non-production builds of the Wiki.
+            title: "Test Suite",
+            description: "(Dev Only) Suite for testing the Wiki elements and features.",
             icon: mdiTestTube,
             separation: false,
         },
@@ -179,7 +180,7 @@
 <div class="hero" style:--i="url({heroHeader})">
     <Container>
         <div>
-            <h1>Welcome to the Strata Wiki</h1>
+            <h1>Welcome to the Strata Source Wiki</h1>
         </div>
     </Container>
 </div>

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -10,7 +10,7 @@
         "Portal 2: Wiki Edition",
         "Sixteen Times The Pages",
         "Not to be confused with the Strata Layer",
-        "To be confused with the Strata Wiki",
+        "To be confused with the Strata Source Wiki",
         "Making Source 20% cooler",
         "Works on my machine™",
         "Beware: ambient_generic on premises",

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -35,6 +35,17 @@
         "WARNING: Too many light styles on a face at (-81.000000, 1002.000000, -63.750000)",
         "Breaking news: Wallace Wrench has lost his wrench.",
         "Now with up to 46% more bugs!",
+        "Now with 5x the crashing",
+        "Try our NEW Strata protein bars, available in 57 different flavors!",
+        "Adding Revolutionary Momentum to the Community",
+        "Coming soon to a [brand-friendly store] near you!",
+        "Cat? What cat?",
+        "Huh? Behind the walls... Can you do it?",
+        "Have you tried unplugging it and plugging it back in?",
+        "It's me, Gordon, Barney from Black Mesa!",
+        "Metal_SeafloorCar.BulletImpact",
+        "Run ALT+F4 for a fun surprise!",
+        "Made by nerds, for nerds."
     ]);
 
     for (let i = messages.length - 1; i >= 0; i--) {

--- a/src/routes/SidebarTopic.svelte
+++ b/src/routes/SidebarTopic.svelte
@@ -42,7 +42,7 @@
 
 <div class="menu">
     {#if menu}
-        {#each menu.subtopics as topic}
+        {#each menu.subtopics as topic (topic.id)}
             <details open={$currentTopic?.startsWith(topic.id)}>
                 <summary
                     class:active={$currentTopic?.startsWith(topic.id)}
@@ -56,7 +56,7 @@
                     <SidebarTopic menu={topic}></SidebarTopic>
                 {/if}
 
-                {#each filterArticles(topic.articles) as article, i}
+                {#each filterArticles(topic.articles) as article, i (i)}
 
                     {#if i < 100 || loaded}
                         <a

--- a/src/routes/[category]/+page.svelte
+++ b/src/routes/[category]/+page.svelte
@@ -15,7 +15,7 @@
 
 <h1>{data.meta.title}</h1>
 
-{#each data.menu.subtopics as topic}
+{#each data.menu.subtopics as topic (topic.id)}
     <div>
         <Link href="/{topic.id}">{topic.title}</Link>
     </div>

--- a/src/routes/[category]/[...article]/+page.svelte
+++ b/src/routes/[category]/[...article]/+page.svelte
@@ -37,7 +37,7 @@
 
     <h1>{data.menu?.title}</h1>
 
-    {#each data.menu?.subtopics || [] as subtopics}
+    {#each data.menu?.subtopics || [] as subtopics (subtopics.id)}
         <div>
             <Link
                 href="/{subtopics.id}">{subtopics.title}</Link
@@ -45,7 +45,7 @@
         </div>
     {/each}
 
-    {#each data.menu?.articles || [] as article}
+    {#each data.menu?.articles || [] as article (article.id)}
         {#if !article.meta.hidden}
             <div>
                 <Link
@@ -92,7 +92,7 @@
     </div>
 
     {#key data}
-        {#each data.doc?.children || [] as obj}
+        {#each data.doc?.children || [] as obj (obj.position)}
             <RootRenderer dat={obj}></RootRenderer>
         {/each}
     {/key}

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -9,7 +9,7 @@
     let { data }: Props = $props();
 </script>
 
-{#each data.categories as category}
+{#each data.categories as category (category.id)}
     <div>
         <Link href="/{category.id}">{category.title}</Link>
     </div>

--- a/src/routes/issues/+page.svelte
+++ b/src/routes/issues/+page.svelte
@@ -58,7 +58,7 @@
             }
 
             return b[1].links.length - a[1].links.length;
-        }) as [id, issue]}
+        }) as [id, issue] (id)}
             <Notice type={issue.level} title={issue.message}>
                 {#if issue.links.length == 1}
                     Found on <Link href="/{issue.links[0]}"
@@ -68,7 +68,7 @@
                     <details>
                         <summary>Found on {issue.links.length} pages</summary>
                         <ol>
-                            {#each issue.links as link}
+                            {#each issue.links as link (link)}
                                 <li>
                                     <Link href="/{link}">/{link}</Link>
                                 </li>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -93,7 +93,7 @@
         {:else if loading > 0}
             <div class="center">Loading...</div>
         {:else}
-            {#each results as result}
+            {#each results as result (result)}
                 <a href={result.url.slice(0, -5)} class="card">
                     <h3>
                         {result.meta.title}


### PR DESCRIPTION
The menu cleanup changes I have had as commits on a different branch `feat/as-parssing-update` for some time, and it was best for me to just finally get these on the front page since they aren't vital to that branch specifically. These are very small insignificant changes I wanted off the AS branch I had.

## Changes:
* Fixed spelling and capitalization for some of the front page section titles and descriptions.
* Added some more footer messages.
* Added some more comments on how the sections are done for the next person who looks at how to add or edit the sections on the front page.
* Apparently, the VSCode Svelte extension has been updated to enforce having keys for `#each` statements so items can be updated correctly (https://svelte.dev/docs/svelte/each#Keyed-each-blocks). This doesn't cause errors normally, and the Wiki works fine, but wherever it appears, it will show as an error in code. This has been fixed.